### PR TITLE
Portability: NAME_MAX is MAXNAMLEN on BSD

### DIFF
--- a/arx/src/lib_stat.c
+++ b/arx/src/lib_stat.c
@@ -15,6 +15,10 @@
 #include <sys/stat.h>
 #include "arx_def.h"
 
+#if defined(MAXNAMLEN) && !defined(NAME_MAX)
+#define NAME_MAX MAXNAMLEN
+#endif
+
 struct file *lib_stat (char *f)
 {
 static struct file	fi;


### PR DESCRIPTION
Cf. https://www.gnu.org/software/libc/manual/html_node/Limits-for-Files.html#index-MAXNAMLEN